### PR TITLE
initialize mu array in bulk_potential 

### DIFF
--- a/src/potentials.f90
+++ b/src/potentials.f90
@@ -22,6 +22,9 @@ module potentials
         ny = size(mu,2)
         n = size(a)
 
+        !Initialize mu array with zero values
+        mu = 0.0
+
         ! Loop filling the mu array
         do j=1,ny
             do i=1,nx


### PR DESCRIPTION
Initialize mu array in bulk potential to zero before new calculation so that previous iteration values for time evolution are not used